### PR TITLE
fix bug when name=null for anonymous user

### DIFF
--- a/src/utils/LeaderBoardJsonTransformer.js
+++ b/src/utils/LeaderBoardJsonTransformer.js
@@ -70,7 +70,7 @@ const leaderBoardJsonTransformer = (apiJsonResponse) => {
         let userAsRGBColor = stringToHexColor(apiJsonResponse['members'][userId]['name'] + userId);
 
         let dataset = {
-            label: apiJsonResponse['members'][userId]['name'],
+            label: apiJsonResponse['members'][userId]['name'] || "anonymous" + userId,
             data: [],
             fill: false,
             backgroundColor: userAsRGBColor,

--- a/src/utils/LeaderBoardJsonTransformer.test.js
+++ b/src/utils/LeaderBoardJsonTransformer.test.js
@@ -17,6 +17,7 @@ test('Transform empty leaderboard', () => {
 });
 
 
+
 test('Transform leaderboard with a single member that has not resolved any problem', () => {
   let jsonData = {
     "event": "2020",
@@ -45,6 +46,40 @@ test('Transform leaderboard with a single member that has not resolved any probl
         fill: false,
         backgroundColor: '#43456C',
         borderColor: '#43456C'
+      }
+    ]
+  });
+})
+
+
+test('Transform leaderboard with a single null member that has not resolved any problem', () => {
+  let jsonData = {
+    "event": "2020",
+    "members": {
+      "123456": {
+        "global_score": 0,
+        "stars": 0,
+        "id": "123456",
+        "local_score": 0,
+        "last_star_ts": 0,
+        "completion_day_level": {},
+        "name": null
+      }
+    },
+    "owner_id": "123456"
+  }
+
+  let result = leaderBoardJsonTransformer(jsonData)
+
+  expect(result).toEqual({
+    labels: [],
+    datasets: [
+      {
+        label: 'anonymous123456',
+        data: [],
+        fill: false,
+        backgroundColor: '#6B4AAA',
+        borderColor: '#6B4AAA'
       }
     ]
   });


### PR DESCRIPTION
Hi, 
when test with a private leaderboard I found a bug that happens when there is a null name which is the case for anonymous users.
I changed the leaderBoardJsonTransformer function to take into account this case and added a test.